### PR TITLE
Update DVC repository URL in vLLM Annotator notebook to not use branch

### DIFF
--- a/flightpaths/vLLM Annotator.ipynb
+++ b/flightpaths/vLLM Annotator.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "sut_id = \"demo_yes_no\"\n",
     "experiment = \"new_annotator_experiment\"\n",
-    "dvc_repo = \"https://github.com/mlcommons/modelplane.git#vllm-flightpath\"\n",
+    "dvc_repo = \"https://github.com/mlcommons/modelplane.git\"\n",
     "prompts = \"flightpaths/data/demo_prompts_mini.csv\"\n",
     "ground_truth = \"data/fakegroundtruth.csv\"\n",
     "cache_dir = None\n",


### PR DESCRIPTION
Had to use the branch since the DVC files weren't on main, so the CI would fail otherwise. But now it's merged to main ( #55 ).